### PR TITLE
Fix: Make download agnostic to the default branch

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -35,11 +35,18 @@ read -p "Is this correct? If so, press enter to continue"
         # b. If it worked, enter the repo, add Auto-Mech as a remote, and add the branch
         # both locally and on GitHub
         (
-            cd ${repo} && \
+            # i. Enter the repository
+            cd ${repo}
+            # ii. If the desired branch isn't the default one, fetch it from origin and
+            # switch to it
+            branch=$( git branch | tr -d [*] | xargs )
+            if [[ ${branch} != ${BRANCH} ]]; then
+                git fetch origin ${BRANCH} && \
+                git branch ${BRANCH} FETCH_HEAD && \
+                git checkout ${BRANCH}
+            fi
+            # iii. Rebase the selected branch against upstream
             git remote add upstream https://github.com/Auto-Mech/${repo} && \
-            git fetch origin ${BRANCH} && \
-            git branch ${BRANCH} FETCH_HEAD && \
-            git checkout ${BRANCH} && \
             git pull --rebase upstream ${BRANCH} && \
             git push origin ${BRANCH}
         )


### PR DESCRIPTION
Future devs will automatically have `dev` as the default branch from their fork, but current devs may have `master` as their default branch.

This allows the download script to work either way.