### PR TITLE
Better activation command and use 'quick' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,16 @@ To test that the code is operational, you can run the "simple" example provided 
 MechDriver repository as follows.
 ```
 pixi shell  # activate the environment
-cd src/mechdriver/examples/simple/
+cd examples/quick/
 automech run &> out.log &
 ```
 Running `automech run --help` will allow you to see the options for this command.
 
-To run from a different directory, you can do the following:
+If you want to activate this Pixi environment from within a shell script, the best way to do that is with the following command:
 ```
-pixi run --manifest-path /path/to/amech-dev/pixi.toml automech run -p /path/to/job &> out.log &
+eval "$(pixi shell-hook --manifest-path /path/to/amech-dev/pixi.toml)"
 ```
+You will need to edit the path to point to wherever you cloned this repository.
 
 To see available MechAnalyzer commands for things like stereoexpansion and sorting, run `mechanalyzer --help`.
 

--- a/examples/quick/inp/theory.dat
+++ b/examples/quick/inp/theory.dat
@@ -15,12 +15,3 @@ level mp2
     mem = 16.0
     nprocs = 1
 end level
-
-level f12
-    method = mp2-f12d-ri
-    basis = cc-pvdz-f12
-    orb_res = RU
-    program = orca4
-    mem = 16.0
-    nprocs = 1
-end level

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,6 +43,7 @@ parallel = ">=20240722,<20240723"
 
 [system-requirements]
 linux="3.10"
+libc = { family="glibc", version="2.17" }
 
 # Dev dependencies
 [pypi-dependencies]


### PR DESCRIPTION
Also, allows the environment to work on systems with older glibc version.