### PR TITLE
Subtask run script

### DIFF
--- a/scripts/subtasks.sh
+++ b/scripts/subtasks.sh
@@ -1,11 +1,36 @@
 #!/usr/bin/env bash
 
+# Optionally, read in the subtask directory path with a `-p` argment
+# (Must be the first argument)
+SUBTASK_PATH="subtasks"
+while getopts ":p:" opt; do
+  case $opt in
+    p)
+      SUBTASK_PATH=$OPTARG
+      set -- "${@:3}" # remove flag and argument from list of nodes
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Read in the list of nodes
 read -a NODES <<< "${@}"
 FIRST_NODE=${NODES[0]}
 NODES_CSV="$(printf '%s,' ${NODES[@]})"
 
+echo "Arguments:"
+echo "  SUBTASK_PATH=${SUBTASK_PATH}"
+echo "  NODES_CSV=${NODES_CSV}"
+
 ACTIVATION_HOOK="$(pixi shell-hook)"
-RUN_COMMAND="automech subtasks run-adhoc -n ${NODES_CSV} -a ${ACTIVATION_HOOK@Q}"
+RUN_COMMAND="automech subtasks run-adhoc -p ${SUBTASK_PATH} -n ${NODES_CSV} -a ${ACTIVATION_HOOK@Q}"
 SCRIPT_HEADER='
     echo Running on $(hostname) in $(pwd)
     echo Process ID: $$

--- a/scripts/subtasks.sh
+++ b/scripts/subtasks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+read -a NODES <<< "${@}"
+FIRST_NODE=${NODES[0]}
+NODES_CSV="$(printf '%s,' ${NODES[@]})"
+
+ACTIVATION_HOOK="$(pixi shell-hook)"
+RUN_COMMAND="automech subtasks run-adhoc -n ${NODES_CSV} -a ${ACTIVATION_HOOK@Q}"
+SCRIPT_HEADER='
+    echo Running on $(hostname) in $(pwd)
+    echo Process ID: $$
+'
+SCRIPT="
+    ${SCRIPT_HEADER}
+    echo Run command: ${RUN_COMMAND}
+    ${RUN_COMMAND}
+"
+
+ssh ${FIRST_NODE} /bin/env bash << EOF
+    set -e
+    cd $(pwd)
+    ${SCRIPT_HEADER}
+    eval ${ACTIVATION_HOOK@Q}
+    nohup sh -c ${SCRIPT@Q} > sub.log 2>&1 &
+EOF


### PR DESCRIPTION
Eventually, this will be callable as a pixi task using, for example, `pixi run subtasks csed-00{36..39}`

For now, it must be called as follows:
```
$PIXI_PROJECT_ROOT/scripts/subtasks.sh csed-00{36..39}
```

If subtasks are stored under a non-default directory name, such as `subtasks2`, one can do the following:
```
$PIXI_PROJECT_ROOT/scripts/subtasks.sh -p subtasks2 csed-00{36..39}
```
Note that the `-p` flag *must come first, before the list of nodes*.