### PR TITLE
Generalizes amech Pixi task to run any command on a node

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -15,7 +15,7 @@ status = { cmd = "./scripts/status.sh", cwd = "." }
 update = { cmd = "./scripts/update.sh", cwd = "." }
 test = { cmd = "./scripts/test.py", cwd = "." }
 subtasks = { cmd = "./scripts/subtasks.sh" }
-amech = { cmd = "./scripts/amech.sh" }
+node = { cmd = "./scripts/node.sh" }
 
 [dependencies]
 python = "3.10.*"

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -7,21 +7,22 @@ WD=${INIT_CWD:-$(pwd)}
 # (Must be the first argument)
 NODE=${1}
 LOG=${2:-"out.log"}
+COMMAND=${3:-"automech run"}
 
 echo "Arguments:"
 echo "  NODE=${NODE}"
 echo "  LOG=${LOG}"
+echo "  COMMAND=${COMMAND}"
 
 ACTIVATION_HOOK="$(pixi shell-hook)"
-RUN_COMMAND="automech run"
 SCRIPT_HEADER='
     echo Running on $(hostname) in $(pwd)
     echo Process ID: $$
 '
 SCRIPT="
     ${SCRIPT_HEADER}
-    echo Run command: ${RUN_COMMAND}
-    ${RUN_COMMAND}
+    echo Run command: ${COMMAND}
+    ${COMMAND}
 "
 
 # Enter working directory and initiate job from the first SSH node

--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -1,3 +1,1 @@
 - name: quick
-  nodes: 
-  - csed-0005


### PR DESCRIPTION
The new task can be used as follows:
```
pixi run node <node> <log file> <command>
```
If unspecified, the default command is "automech run" and the default log file is "out.log".

Examples:
```
pixi run node csed-0001  			   	# run AutoMech
pixi run node csed-0001 out.log "g16 run.inp run.out"  	# run Gaussian
```