### PR TITLE
Fix: Run tests in serial

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,4 +26,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pixi run pytest -n auto -v src/mechdriver/tests/
+          pixi run pytest -v src/mechdriver/tests/


### PR DESCRIPTION
Uses of os.chdir() do not play well with running concurrently.